### PR TITLE
Fixed theme_download variable initialization.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -64,10 +64,9 @@ class themeDownload extends Plugin{
                         var data = JSON.parse(data);
                         var theme_name = data.name;
                         var theme_version = data.version;
-                        var theme_version = data.version;
                         var theme_download = data.download_url;
-                        if(data.download_url_v2 != ""){
-                            var theme_download = data.download_url_v2;
+                        if(data.download_url_v2 != undefined){
+                            theme_download = data.download_url_v2;
                         }
                         var theme_information_url = data.information_url;
                         var theme_description = data.description;


### PR DESCRIPTION
I had problem with downloading themes via your plugin and found that variable `theme_download` is not properly initialized. The condition `data.download_url_v2 != ""` was actually `true` for non-existing url (is is `undefined`, not empty string).

Also you had duplicated line, so I removed it :)